### PR TITLE
Update to 2.10.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+# the conda-build parameters to use for disabling --skip-existing
+# See https://github.com/conda/conda-build/issues/4856.
+build_parameters:
+  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-# the conda-build parameters to use for disabling --skip-existing
-build_parameters:
-  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+# the conda-build parameters to use for disabling --skip-existing
+build_parameters:
+  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-# the conda-build parameters to use for disabling --skip-existing
-# See https://github.com/conda/conda-build/issues/4856.
-build_parameters:
-  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,6 +3,7 @@
 
 # this is set to PYBIND11_INTERNALS_VERSION
 {% set abi_version = "4" %}
+{% set abi_buildnumber = "1" %}
 
 package:
   name: pybind11-split
@@ -20,6 +21,7 @@ outputs:
   - name: pybind11-abi
     version: {{ abi_version }}
     build:
+      number: {{ abi_buildnumber }}
       noarch: generic
       skip: true  # [not linux and x86_64]
       run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.10.1" %}
-{% set sha256 = "111014b516b625083bef701df7880f78c2243835abdb263065b6b59b960b6bad" %}
+{% set version = "2.10.4" %}
+{% set sha256 = "832e2f309c57da9c1e6d4542dedd34b24e4192ecb4d62f6f4866a737454c9970" %}
 
 # this is set to PYBIND11_INTERNALS_VERSION
 {% set abi_version = "4" %}
@@ -29,7 +29,7 @@ outputs:
         - include/pybind11/detail/internals.h
       commands:
         # make sure the internals version matches the package version
-        - if [ $(grep "#define PYBIND11_INTERNALS_VERSION" include/pybind11/detail/internals.h | cut -d' ' -f3) != "{{ abi_version }}" ]; then exit 1; fi
+        - if [[ $(grep "#[[:blank:]]*define PYBIND11_INTERNALS_VERSION" include/pybind11/detail/internals.h | rev | cut -d' ' -f1) != "{{ abi_version }}" ]]; then exit 1; fi
 
   - name: pybind11-global
     script: build-pybind11-global.sh  # [unix]


### PR DESCRIPTION
Diff between 2.10.1 and 2.10.4: https://github.com/pybind/pybind11/compare/v2.10.1..v2.10.4.

Required by https://github.com/AnacondaRecipes/dpctl-feedstock/pull/3.