### PR TITLE
update to 2.12.0

### DIFF
--- a/recipe/build-pybind11-global.bat
+++ b/recipe/build-pybind11-global.bat
@@ -2,5 +2,5 @@
 :: https://github.com/conda/conda-build/blob/d75ef9c66dbcc832d8d96f33a2aecfe893266e8c/conda_build/build.py#L2517-L2527
 set PYBIND11_GLOBAL_SDIST=1
 set PYBIND11_GLOBAL_PREFIX=Library
-%PYTHON% -m pip install . -vv --no-build-isolation
+%PYTHON% -m pip install . -vv --no-build-isolation --no-deps
 if errorlevel 1 exit 1

--- a/recipe/build-pybind11-global.sh
+++ b/recipe/build-pybind11-global.sh
@@ -1,4 +1,4 @@
 # There are several required flags, like --no-deps, but conda-build nicely sets them for us
 # https://github.com/conda/conda-build/blob/d75ef9c66dbcc832d8d96f33a2aecfe893266e8c/conda_build/build.py#L2517-L2527
 export PYBIND11_GLOBAL_SDIST=1
-$PYTHON -m pip install . -vv --no-build-isolation
+$PYTHON -m pip install . -vv --no-build-isolation --no-deps

--- a/recipe/build-pybind11.bat
+++ b/recipe/build-pybind11.bat
@@ -1,4 +1,4 @@
 :: There are several required flags, like --no-deps, but conda-build nicely sets them for us
 :: https://github.com/conda/conda-build/blob/d75ef9c66dbcc832d8d96f33a2aecfe893266e8c/conda_build/build.py#L2517-L2527
-%PYTHON% -m pip install . -vv --no-build-isolation
+%PYTHON% -m pip install . -vv --no-build-isolation --no-deps
 if errorlevel 1 exit 1

--- a/recipe/build-pybind11.sh
+++ b/recipe/build-pybind11.sh
@@ -1,3 +1,3 @@
 # There are several required flags, like --no-deps, but conda-build nicely sets them for us
 # https://github.com/conda/conda-build/blob/d75ef9c66dbcc832d8d96f33a2aecfe893266e8c/conda_build/build.py#L2517-L2527
-$PYTHON -m pip install . -vv --no-build-isolation
+$PYTHON -m pip install . -vv --no-build-isolation --no-deps

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.10.4" %}
-{% set sha256 = "832e2f309c57da9c1e6d4542dedd34b24e4192ecb4d62f6f4866a737454c9970" %}
+{% set version = "2.12.0" %}
+{% set sha256 = "bf8f242abd1abcd375d516a7067490fb71abd79519a282d22b6e4d19282185a7" %}
 
 # this is set to PYBIND11_INTERNALS_VERSION
 {% set abi_version = "4" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,6 +2,8 @@
 {% set sha256 = "bf8f242abd1abcd375d516a7067490fb71abd79519a282d22b6e4d19282185a7" %}
 
 # this is set to PYBIND11_INTERNALS_VERSION
+# pybind11 now defines two ABI version. 4 and 5 for 3.12+ or msvc.
+# https://github.com/pybind/pybind11/blob/v2.12.0/include/pybind11/detail/internals.h#L40
 {% set abi_version = "4" %}     # [py<312 and not win]
 {% set abi_buildnumber = "1" %} # [py<312 and not win]
 {% set abi_version = "5" %}     # [py>=312 or win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,8 +2,10 @@
 {% set sha256 = "bf8f242abd1abcd375d516a7067490fb71abd79519a282d22b6e4d19282185a7" %}
 
 # this is set to PYBIND11_INTERNALS_VERSION
-{% set abi_version = "4" %}
-{% set abi_buildnumber = "1" %}
+{% set abi_version = "4" %}     # [py<312 and not win]
+{% set abi_buildnumber = "1" %} # [py<312 and not win]
+{% set abi_version = "5" %}     # [py>=312 or win]
+{% set abi_buildnumber = "0" %} # [py>=312 or win]
 
 package:
   name: pybind11-split
@@ -31,7 +33,7 @@ outputs:
         - include/pybind11/detail/internals.h
       commands:
         # make sure the internals version matches the package version
-        - if [[ $(grep "#[[:blank:]]*define PYBIND11_INTERNALS_VERSION" include/pybind11/detail/internals.h | rev | cut -d' ' -f1) != "{{ abi_version }}" ]]; then exit 1; fi
+        - matched=false; while read -r version; do [ "$version" -eq "{{ abi_version }}" ] && { matched=true; break; }; done < <(awk '/define PYBIND11_INTERNALS_VERSION/{print $NF}' include/pybind11/detail/internals.h); [ "$matched" = true ] && exit 0 || exit 1
 
   - name: pybind11-global
     script: build-pybind11-global.sh  # [unix]


### PR DESCRIPTION
Changes:
- update to 2.12.0

https://github.com/pybind/pybind11/tree/v2.12.0

Note:
pybind11 now defines two ABI version. 4 and 5 for 3.12+ or msvc.
https://github.com/pybind/pybind11/blob/v2.12.0/include/pybind11/detail/internals.h#L40
pybind11-abi is used only by libmambapy (which will require a rebuild).