### PR TITLE
update to 2.12.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+aggregate_check: False

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.12.0" %}
-{% set sha256 = "bf8f242abd1abcd375d516a7067490fb71abd79519a282d22b6e4d19282185a7" %}
+{% set version = "2.12.1" %}
+{% set sha256 = "5326a86a4b3c80d4cf05ecfe0127a699ed6449c185a66f1b77d98e4645c51ba3" %}
 
 # this is set to PYBIND11_INTERNALS_VERSION
 # pybind11 now defines two ABI version. 4 and 5 for 3.12+ or msvc.
@@ -28,6 +28,8 @@ outputs:
       number: {{ abi_buildnumber }}
       noarch: generic
       skip: true  # [not linux and x86_64]
+      # This is currently skipped until `skip-existing` works correctly. 
+      skip: true
       run_exports:
         - pybind11-abi =={{ abi_version }}
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,10 +17,15 @@ source:
   fn: pybind11-{{ version }}.tar.gz
   url: https://github.com/pybind/pybind11/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:  # [win]
+    - patches/0000_win_fix_paths.patch  # [win]
 
 build:
   number: 0
 
+requirements:
+  build:        # [win]
+    - m2-patch  # [win]
 outputs:
   - name: pybind11-abi
     version: {{ abi_version }}
@@ -93,7 +98,7 @@ outputs:
         - test -f ${PREFIX}/include/pybind11/pybind11.h      # [unix]
         - if exist %LIBRARY_INC%\pybind11\pybind11.h (exit 0) else (exit 1)      # [win]
         - test -f $(python -c "import pybind11 as py; print(py.get_include())")/pybind11/pybind11.h      # [unix]
-        - if exist $(python -c "import pybind11 as py; print(py.get_include())")\pybind11\pybind11.h (exit 0) else (exit 1)      # [win]
+        - if not exist %SP_DIR%\pybind11\include\pybind11\pybind11.h exit 1      # [win]
 
 about:
   home: https://github.com/pybind/pybind11/

--- a/recipe/patches/0000_win_fix_paths.patch
+++ b/recipe/patches/0000_win_fix_paths.patch
@@ -1,0 +1,21 @@
+diff --git a/setup.py b/setup.py
+index 96563c1a..80e6ae5d 100644
+--- a/setup.py
++++ b/setup.py
+@@ -122,10 +122,14 @@ def remove_output(*sources: str) -> Generator[None, None, None]:
+ with remove_output("pybind11/include", "pybind11/share"):
+     # Generate the files if they are not present.
+     with TemporaryDirectory() as tmpdir:
+-        cmd = ["cmake", "-S", ".", "-B", tmpdir] + [
++        cmd = ["cmake", '-GVisual Studio 16 2019', "-S", ".", "-B", tmpdir] + [
+             "-DCMAKE_INSTALL_PREFIX=pybind11",
+             "-DBUILD_TESTING=OFF",
+             "-DPYBIND11_NOPYTHON=ON",
++            '-DPYTHON_EXECUTABLE:FILEPATH='+os.environ.get("PYTHON",""),
++            '-DPYTHON_LIBRARY:FILEPATH='+os.environ.get("PYTHON_LIBRARY",""),
++            '-DPYTHON_INCLUDE_DIR:PATH='+os.environ.get("PREFIX","")+ '\include',
++            '-DCMAKE_PREFIX_PATH='+os.environ.get("LIBRARY_PREFIX",""),
+             "-Dprefix_for_pc_file=${pcfiledir}/../../",
+         ]
+         if "CMAKE_ARGS" in os.environ:
+


### PR DESCRIPTION
pybind11 2.12.1

**Destination channel:** main

### Links

- PKG-6108
- https://github.com/pybind/pybind11/releases
- https://github.com/pybind/pybind11/compare/v2.12.0..v2.12.1

### Explanation of changes:

- Getting the 3.13 variant built for scipy (which requires <2.13).
