### PR TITLE
Copy headers to prefix/include

### DIFF
--- a/recipe/build-pybind11-global.bat
+++ b/recipe/build-pybind11-global.bat
@@ -3,4 +3,7 @@
 set PYBIND11_GLOBAL_SDIST=1
 set PYBIND11_GLOBAL_PREFIX=Library
 %PYTHON% -m pip install . -vv --no-build-isolation --no-deps
+
+:: Copy the headers to the global include directory to match how the pip package behaves. 
+cp -r %PREFIX%/include/pybind11_global/* %PREFIX%/include
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - patches/0000_win_fix_paths.patch  # [win]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:        # [win]


### PR DESCRIPTION
pybind11 rebuild

## Changes
- Bump build number
- Copy header files to `%PREFIX%/include/pybind11` this matches the functionality of the pip package and allows me to remove a hack that was required here: https://github.com/AnacondaRecipes/pytorch-feedstock/pull/53#discussion_r1926033875