### PR TITLE
Add generated anaconda.yaml

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,7 +1,7 @@
 anaconda_config_version: 1
 upstream_sources:
-  - pypi:
-      identifier: pybind11
+  - github:
+      identifier: pybind/pybind11
     packages:
       - pybind11
       - pybind11-abi


### PR DESCRIPTION
This PR adds generated `anaconda.yaml` (Feedstock Configuration Format).

See the reason https://github.com/AnacondaRecipes/pybind11-feedstock/blob/master/recipe/meta.yaml#L18